### PR TITLE
Overlaping activities

### DIFF
--- a/app/components/sy-timepicker/component.js
+++ b/app/components/sy-timepicker/component.js
@@ -145,6 +145,14 @@ export default Component.extend({
   },
 
   /**
+   * Whether the picker is disabled
+   *
+   * @property {Boolean} disabled
+   * @public
+   */
+  disabled: false,
+
+  /**
    * Increase or decrease the current value
    *
    * If the shift or ctrl key is pressed it changes the hours instead of the

--- a/app/components/sy-timepicker/template.hbs
+++ b/app/components/sy-timepicker/template.hbs
@@ -2,6 +2,7 @@
   type="text"
   class="form-control"
   placeholder="--:--"
+  disabled={{disabled}}
   value={{displayValue}}
   pattern={{pattern}}
   onkeydown={{action 'handleKeyDown'}}

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -14,14 +14,22 @@
         <tbody>
           {{#each blocks as |block|}}
             {{#if (and block.to (not block.isDeleted))}}
-              <tr class="text-center" data-test-activity-block-row data-test-activity-block-row-id={{block.id}}>
+              <tr
+                class="text-center {{if block.overlaps 'danger'}}"
+                title="{{if block.overlaps 'This block overlaps the day of the activity'}}"
+                data-test-activity-block-row
+                data-test-activity-block-row-id={{block.id}}
+              >
                 <td>
                   <button data-test-delete-activity-block class="btn btn-default" {{action 'deleteBlock' block}}>{{fa-icon 'trash'}}</button>
                 </td>
                 <td>{{sy-timepicker max=block.to precision=1 value=block.from on-change=(action (mut block.from))}}</td>
                 <td>-</td>
                 <td>{{sy-timepicker min=block.from precision=1 value=block.to on-change=(action (mut block.to))}}</td>
-                <td>{{format-duration (moment-diff block.from block.to) false}}</td>
+                <td>
+                  {{#if block.overlaps}}<span class="error-text">{{fa-icon 'warning'}}</span>{{/if}}
+                  {{format-duration (moment-diff block.from block.to) false}}
+                </td>
               </tr>
             {{/if}}
           {{/each}}

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -13,7 +13,7 @@
       <table class="table table--striped table--activity-blocks">
         <tbody>
           {{#each blocks as |block|}}
-            {{#if (and block.to (not block.isDeleted))}}
+            {{#unless block.isDeleted}}
               <tr
                 class="text-center {{if block.overlaps 'danger'}}"
                 title="{{if block.overlaps 'This block overlaps the day of the activity'}}"
@@ -23,15 +23,19 @@
                 <td>
                   <button data-test-delete-activity-block class="btn btn-default" {{action 'deleteBlock' block}}>{{fa-icon 'trash'}}</button>
                 </td>
-                <td>{{sy-timepicker max=block.to precision=1 value=block.from on-change=(action (mut block.from))}}</td>
+                <td>{{sy-timepicker disabled=(not block.to) max=block.to precision=1 value=block.from on-change=(action (mut block.from))}}</td>
                 <td>-</td>
-                <td>{{sy-timepicker min=block.from precision=1 value=block.to on-change=(action (mut block.to))}}</td>
+                <td>{{sy-timepicker disabled=(not block.to) min=block.from precision=1 value=block.to on-change=(action (mut block.to))}}</td>
                 <td>
-                  {{#if block.overlaps}}<span class="error-text">{{fa-icon 'warning'}}</span>{{/if}}
-                  {{format-duration (moment-diff block.from block.to) false}}
+                  {{#if block.overlaps}}
+                    <span class="error-text">{{fa-icon 'warning'}}</span>
+                  {{/if}}
+                  {{#if block.to}}
+                    {{format-duration (moment-diff block.from block.to) false}}
+                  {{/if}}
                 </td>
               </tr>
-            {{/if}}
+            {{/unless}}
           {{/each}}
           <tr>
             <td><button data-test-add-activity-block class="btn btn-default" {{action 'addBlock'}}>{{fa-icon 'plus'}}</button></td>

--- a/app/index/activities/route.js
+++ b/app/index/activities/route.js
@@ -101,13 +101,13 @@ export default Route.extend({
      * @public
      */
     generateReportsCheck() {
-      let hasUnknown = this.get('controller.activities').find(a => {
-        return !a.get('task.id')
-      })
-
-      let hasOverlapping = this.get('controller.activities').find(a => {
-        return a.get('overlaps')
-      })
+      let hasUnknown = !!this.get('controller.activities').findBy(
+        'task.id',
+        undefined
+      )
+      let hasOverlapping = !!this.get('controller.activities').findBy(
+        'overlaps'
+      )
 
       this.set('controller.showUnknownWarning', hasUnknown)
       this.set('controller.showOverlappingWarning', hasOverlapping)

--- a/app/index/activities/route.js
+++ b/app/index/activities/route.js
@@ -101,14 +101,12 @@ export default Route.extend({
      * @public
      */
     generateReportsCheck() {
-      let hasUnknown = this.get('controller.activities').find(
-        a => !a.get('task.id')
-      )
+      let hasUnknown = this.get('controller.activities').find(a => {
+        return !a.get('task.id')
+      })
 
-      let hasOverlapping = this.get('controller.activities').any(a => {
-        return a.get('blocks').any(b => {
-          return !(b.get('to') || moment()).isSame(a.get('start'), 'day')
-        })
+      let hasOverlapping = this.get('controller.activities').find(a => {
+        return a.get('overlaps')
       })
 
       this.set('controller.showUnknownWarning', hasUnknown)
@@ -131,14 +129,7 @@ export default Route.extend({
 
       try {
         await this.get('controller.activities')
-          .filter(a => {
-            return (
-              a.get('task.id') &&
-              a.get('blocks').every(b => {
-                return (b.get('to') || moment()).isSame(a.get('start'), 'day')
-              })
-            )
-          })
+          .filter(a => a.get('task.id') && !a.get('overlaps'))
           .forEach(async activity => {
             let duration = moment.duration(activity.get('duration'))
 

--- a/app/index/activities/template.hbs
+++ b/app/index/activities/template.hbs
@@ -9,6 +9,8 @@
         <tbody>
           {{#each activities as |activity|}}
           <tr
+            class="{{if activity.overlaps 'danger'}}"
+            title="Click to edit"
             data-test-activity-row
             data-test-activity-row-id={{activity.id}}
             class="pointer {{if activity.active 'primary'}}"
@@ -27,6 +29,12 @@
               </td>
               <td>{{activity.comment}}</td>
               <td>
+                {{#if activity.overlaps}}
+                  <span title="This activity has an overlapping block" class="error-text">
+                    {{fa-icon 'warning'}}
+                    &nbsp;
+                  </span>
+                {{/if}}
                 {{#if activity.active}}
                   {{duration-since activity.activeBlock.from elapsed=activity.duration}}
                 {{else}}

--- a/app/index/activities/template.hbs
+++ b/app/index/activities/template.hbs
@@ -62,15 +62,28 @@
   </div>
 </div>
 
-{{#sy-modal visible=showWarning as |modal|}}
+{{#sy-modal visible=showOverlappingWarning as |modal|}}
+  {{#modal.header}}
+    Activities overlap
+  {{/modal.header}}
+  {{#modal.body}}
+    Overlapping activities will not be taken into account for the timesheet.
+  {{/modal.body}}
+  {{#modal.footer data-test-overlap-warning}}
+   <button class="btn btn-primary" {{action (if showUnknownWarning (action (mut showOverlappingWarning) false) 'generateReports')}}>That's fine</button>
+   <button class="btn btn-default" {{action (queue (action (mut showOverlappingWarning) false) (action (mut showUnknownWarning) false))}}>Cancel</button>
+  {{/modal.footer}}
+{{/sy-modal}}
+
+{{#sy-modal visible=showUnknownWarning as |modal|}}
   {{#modal.header}}
     Activities contain unknown tasks
   {{/modal.header}}
   {{#modal.body}}
     Unknown tasks will not be taken into account for the timesheet.
   {{/modal.body}}
-  {{#modal.footer}}
-   <button class="btn btn-primary" {{action 'generateReports'}}>That's fine</button>
-   <button class="btn btn-default" {{action (mut showWarning false)}}>Cancel</button>
+  {{#modal.footer data-test-unknown-warning}}
+   <button class="btn btn-primary" {{action (if showOverlappingWarning (action (mut showUnknownWarning) false) 'generateReports')}}>That's fine</button>
+   <button class="btn btn-default" {{action (queue (action (mut showUnknownWarning) false) (action (mut showOverlappingWarning) false))}}>Cancel</button>
   {{/modal.footer}}
 {{/sy-modal}}

--- a/app/models/activity-block.js
+++ b/app/models/activity-block.js
@@ -6,6 +6,7 @@
 import Model from 'ember-data/model'
 import attr from 'ember-data/attr'
 import moment from 'moment'
+import computed from 'ember-computed-decorators'
 
 import { belongsTo } from 'ember-data/relationships'
 
@@ -42,5 +43,16 @@ export default Model.extend({
    * @type {Activity}
    * @public
    */
-  activity: belongsTo('activity')
+  activity: belongsTo('activity'),
+
+  /**
+   * Whether the blocks overlaps a day
+   *
+   * @property {Boolean} overlaps
+   * @public
+   */
+  @computed('activity.start', 'to')
+  overlaps(start, to) {
+    return !(to || moment()).isSame(start, 'day')
+  }
 })

--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -104,8 +104,8 @@ export default Model.extend({
    * @property {Boolean} overlaps
    * @public
    */
-  @computed('blocks.@each.overlaps')
-  overlaps(blocks) {
+  @computed('start', 'blocks.@each.to')
+  overlaps(start, blocks) {
     return blocks.any(b => b.get('overlaps'))
   }
 })

--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -96,5 +96,16 @@ export default Model.extend({
   @computed('activeBlock')
   active(block) {
     return Boolean(block && block.get('from'))
+  },
+
+  /**
+   * Whether the activity has any overlapping blocks
+   *
+   * @property {Boolean} overlaps
+   * @public
+   */
+  @computed('blocks.@each.overlaps')
+  overlaps(blocks) {
+    return blocks.any(b => b.get('overlaps'))
   }
 })

--- a/app/serializers/activity.js
+++ b/app/serializers/activity.js
@@ -24,6 +24,6 @@ export default ApplicationSerializer.extend({
    * @public
    */
   attrs: {
-    start: 'start-datetime'
+    start: 'date'
   }
 })

--- a/mirage/factories/activity-block.js
+++ b/mirage/factories/activity-block.js
@@ -2,7 +2,7 @@ import { Factory, faker, trait } from 'ember-cli-mirage'
 
 export default Factory.extend({
   fromDatetime() {
-    let start = this.activity.startDatetime.clone()
+    let start = this.activity.date.clone()
 
     return start
   },

--- a/mirage/factories/activity.js
+++ b/mirage/factories/activity.js
@@ -7,20 +7,18 @@ export default Factory.extend({
   duration: () => randomDuration(1, true),
   // task: association(),
 
-  startDatetime() {
-    let random = moment(faker.date.past())
-
-    return moment().set({
-      h: random.hours(),
-      m: random.minutes(),
-      s: random.seconds()
-    })
-  },
+  date: () =>
+    moment().set({
+      h: 8,
+      m: 30,
+      s: 0,
+      ms: 0
+    }),
 
   afterCreate(activity, server) {
     activity.update({ taskId: server.create('task').id })
 
-    let toDatetime = activity.startDatetime.clone()
+    let toDatetime = activity.date.clone()
 
     let [hours, minutes, seconds] = activity.duration.split(':').map(parseInt)
 
@@ -28,7 +26,7 @@ export default Factory.extend({
 
     server.create('activity-block', {
       activity,
-      fromDatetime: activity.startDatetime.clone(),
+      fromDatetime: activity.date.clone(),
       toDatetime
     })
   },
@@ -46,6 +44,16 @@ export default Factory.extend({
   unknown: trait({
     afterCreate(activity) {
       activity.task.destroy()
+    }
+  }),
+
+  overlapping: trait({
+    afterCreate(activity, server) {
+      server.create('activity-block', {
+        activity,
+        fromDatetime: moment(),
+        toDatetime: moment().add(1, 'days')
+      })
     }
   })
 })

--- a/tests/acceptance/index-activities-test.js
+++ b/tests/acceptance/index-activities-test.js
@@ -9,7 +9,7 @@ import startApp from '../helpers/start-app'
 import testSelector from 'ember-test-selectors'
 import moment from 'moment'
 
-describe('Acceptance | index activities x', function() {
+describe('Acceptance | index activities', function() {
   let application
 
   beforeEach(async function() {


### PR DESCRIPTION
* User gets a warning when trying to generate a timesheet with an activity which overlaps the day
* Overlapping activities and blocks are highlighted
* Help texts for the user
* Field `start-datetime` was renamed in the backend to `date` for better understanding