### PR TITLE
Minor absence modal fixes

### DIFF
--- a/app/components/sy-modal/overlay/component.js
+++ b/app/components/sy-modal/overlay/component.js
@@ -38,7 +38,7 @@ export default Component.extend({
    */
   click(e) {
     if (e.target === this.get('element')) {
-      this.set('visible', false)
+      this.get('attrs.on-close')()
     }
   }
 })

--- a/app/components/sy-modal/template.hbs
+++ b/app/components/sy-modal/template.hbs
@@ -1,5 +1,5 @@
 {{#ember-wormhole to='sy-modals'}}
-  {{#sy-modal/overlay visible=visible}}
+  {{#sy-modal/overlay visible=visible on-close=(action 'close')}}
     <div class="modal-dialog {{if size (concat 'modal-dialog--' size)}}">
       {{yield (hash
         header = (component 'sy-modal/header' close=(action 'close'))

--- a/app/index/controller.js
+++ b/app/index/controller.js
@@ -65,16 +65,6 @@ export default Controller.extend({
    */
   session: service('session'),
 
-  init() {
-    this._super(...arguments)
-
-    this.set('newAbsence', {
-      dates: [],
-      comment: '',
-      type: null
-    })
-  },
-
   /**
    * All activities
    *
@@ -509,6 +499,8 @@ export default Controller.extend({
      * @public
      */
     rollback(changeset) {
+      this.get('setCenter').perform({ moment: this.get('date') })
+
       changeset.rollback()
     }
   }

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -110,6 +110,12 @@ export default Route.extend(RouteAutostartTourMixin, {
 
     controller.set('user', this.modelFor('protected'))
     controller.get('setCenter').perform({ moment: model })
+
+    controller.set('newAbsence', {
+      dates: [model],
+      comment: '',
+      type: null
+    })
   },
 
   actions: {
@@ -176,6 +182,8 @@ export default Route.extend(RouteAutostartTourMixin, {
 
           await absence.save()
         })
+
+        changeset.rollback()
 
         this.set('controller.showAddModal', false)
       } catch (e) {

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -140,7 +140,7 @@ describe('Acceptance | index', function() {
     expect(document.title).to.match(/\d{2}:\d{2}:\d{2} \(Unknown Task\)/)
   })
 
-  it('can add an absence for multiple days', async function() {
+  it('can add an absence for multiple days and current day is preselected', async function() {
     server.loadFixtures('absence-types')
 
     await visit('/?day=2017-06-29')
@@ -152,7 +152,6 @@ describe('Acceptance | index', function() {
     await click('[data-test-add-absence-form] .btn-group .btn:first-child')
 
     await click(find('[data-date=2017-06-28]'))
-    await click(find('[data-date=2017-06-29]'))
     await click(find('[data-date=2017-06-30]'))
 
     await click('[data-test-add-absence-form] button:contains(Save)')
@@ -218,5 +217,25 @@ describe('Acceptance | index', function() {
 
     expect(find('[data-test-weekly-overview-day=29].holiday')).to.have.length(1)
     expect(find('[data-test-weekly-overview-day=28].holiday')).to.have.length(0)
+  })
+
+  it('rollbacks the absence modal', async function() {
+    await visit('/?day=2017-06-29')
+
+    await click('[data-test-add-absence]')
+
+    await click('[data-date=2017-06-30]')
+
+    expect(
+      find('[data-date=2017-06-29].ember-power-calendar-day--selected')
+    ).to.have.length(1)
+
+    await click('[data-test-add-absence-form] .close')
+
+    await click('[data-test-add-absence]')
+
+    expect(
+      find('[data-date=2017-06-30].ember-power-calendar-day--selected')
+    ).to.have.length(0)
   })
 })

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -224,10 +224,14 @@ describe('Acceptance | index', function() {
 
     await click('[data-test-add-absence]')
 
+    expect(
+      find('[data-date=2017-06-29].ember-power-calendar-day--selected')
+    ).to.have.length(1)
+
     await click('[data-date=2017-06-30]')
 
     expect(
-      find('[data-date=2017-06-29].ember-power-calendar-day--selected')
+      find('[data-date=2017-06-30].ember-power-calendar-day--selected')
     ).to.have.length(1)
 
     await click('[data-test-add-absence-form] .close')

--- a/tests/integration/components/sy-modal/overlay/component-test.js
+++ b/tests/integration/components/sy-modal/overlay/component-test.js
@@ -16,8 +16,11 @@ describe('Integration | Component | sy modal/overlay', function() {
 
   it('closes on click', function() {
     this.set('visible', true)
+    this.on('close', () => this.set('visible', false))
 
-    this.render(hbs`{{sy-modal/overlay visible=visible}}`)
+    this.render(
+      hbs`{{sy-modal/overlay visible=visible on-close=(action 'close')}}`
+    )
 
     expect(this.get('visible')).to.be.ok
 
@@ -28,9 +31,10 @@ describe('Integration | Component | sy modal/overlay', function() {
 
   it('does not close on click of a child element', function() {
     this.set('visible', true)
+    this.on('close', () => this.set('visible', false))
 
     this.render(hbs`
-      {{#sy-modal/overlay visible=visible}}
+      {{#sy-modal/overlay visible=visible on-close=(action 'close')}}
         <div id="some-child">Test</div>
       {{/sy-modal/overlay}}
     `)


### PR DESCRIPTION
* Rollback the modal data after closing it
* Set the center of the calendar to the selected date
* Preselect the selected date in the new absence calendar