### PR TITLE
Set the date of an activity before starting it the first time

### DIFF
--- a/app/index/activities/route.js
+++ b/app/index/activities/route.js
@@ -81,7 +81,6 @@ export default Route.extend(RouteAutostartTourMixin, {
     async startActivity(activity) {
       if (!activity.get('date').isSame(moment(), 'day')) {
         activity = this.store.createRecord('activity', {
-          date: moment(),
           ...activity.getProperties('task', 'comment')
         })
       }

--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -122,6 +122,8 @@ export default Model.extend({
     }
 
     if (this.get('isNew')) {
+      this.set('date', moment())
+
       await this.save()
     }
 

--- a/app/services/tracking.js
+++ b/app/services/tracking.js
@@ -177,8 +177,7 @@ export default Service.extend({
       return this.get('_activity')
     },
     set(value) {
-      let newActivity =
-        value || this.get('store').createRecord('activity', { date: moment() })
+      let newActivity = value || this.get('store').createRecord('activity')
 
       this.set('_activity', newActivity)
 


### PR DESCRIPTION
Before this fix, the date on an activity was set while creating it. This resulted in unsaved activities which had a date of a past day so after saving it, it had a way too long duration.