### PR TITLE
Only show users list to superuser

### DIFF
--- a/app/components/sy-sidenav/template.hbs
+++ b/app/components/sy-sidenav/template.hbs
@@ -30,11 +30,13 @@
         {{fa-icon 'bar-chart'}} Statistics
       {{/link-to}}
     </li>
-    <li class="nav-side-list-item">
-      {{#link-to 'users.index'}}
-        {{fa-icon 'users'}} Users
-      {{/link-to}}
-    </li>
+    {{#if user.isSuperuser}}
+      <li class="nav-side-list-item">
+        {{#link-to 'users.index'}}
+          {{fa-icon 'users'}} Users
+        {{/link-to}}
+      </li>
+    {{/if}}
     {{#if user.isStaff}}
       <li class="nav-side-list-item">
         {{#link-to 'reschedule'}}


### PR DESCRIPTION
We don't need to show everyone the users list, since those who can actually see users there can access them over the responsibility tab in their profile.