### PR TITLE
Fix style for date buttons

### DIFF
--- a/app/components/date-buttons/styles.scss
+++ b/app/components/date-buttons/styles.scss
@@ -1,0 +1,3 @@
+.date-button {
+  width: 32.5%;
+}

--- a/app/components/date-buttons/template.hbs
+++ b/app/components/date-buttons/template.hbs
@@ -1,3 +1,3 @@
 {{#each choices as |choice index|}}
-  <button class="btn" {{action "selectDate" choice}} data-test-preset-date={{index}}>{{choice}}</button>
+  <button class="btn date-button" {{action "selectDate" choice}} data-test-preset-date={{index}}>{{choice}}</button>
 {{/each}}


### PR DESCRIPTION
The last date button was previously being pushed underneath the others.