### PR TITLE
Add additional filter options for reports

### DIFF
--- a/app/analysis/index/template.hbs
+++ b/app/analysis/index/template.hbs
@@ -107,7 +107,10 @@
             on-change = (action (mut toDate))
           }}
         {{/fs.label}}
-        {{date-buttons presetDate=(action (mut fromDate))}}
+        {{date-buttons
+            onUpdateFromDate=(action (mut fromDate))
+            onUpdateToDate=(action (mut toDate))
+        }}
       {{/fs.group}}
       {{#fs.group label='State'}}
         {{#fs.label}}

--- a/app/components/date-buttons/component.js
+++ b/app/components/date-buttons/component.js
@@ -4,20 +4,66 @@ import moment from 'moment'
 export default Component.extend({
   init() {
     this._super(...arguments)
-    this.set('choices', ['this week', 'this month', 'this year'])
+    this.set('choices', [
+      'this week',
+      'this month',
+      'this year',
+      'last week',
+      'last month',
+      'last year'
+    ])
   },
 
   actions: {
     selectDate(expr) {
       switch (expr) {
         case 'this week':
-          this.get('presetDate')(moment().day(1))
+          this.get('onUpdateFromDate')(moment().day(1))
+          this.get('onUpdateToDate')(null)
           break
         case 'this month':
-          this.get('presetDate')(moment().date(1))
+          this.get('onUpdateFromDate')(moment().date(1))
+          this.get('onUpdateToDate')(null)
           break
         case 'this year':
-          this.get('presetDate')(moment().dayOfYear(1))
+          this.get('onUpdateFromDate')(moment().dayOfYear(1))
+          this.get('onUpdateToDate')(null)
+          break
+        case 'last week':
+          this.get('onUpdateFromDate')(
+            moment()
+              .subtract(1, 'week')
+              .day(1)
+          )
+          this.get('onUpdateToDate')(
+            moment()
+              .subtract(1, 'week')
+              .day(7)
+          )
+          break
+        case 'last month':
+          this.get('onUpdateFromDate')(
+            moment()
+              .subtract(1, 'month')
+              .startOf('month')
+          )
+          this.get('onUpdateToDate')(
+            moment()
+              .subtract(1, 'month')
+              .endOf('month')
+          )
+          break
+        case 'last year':
+          this.get('onUpdateFromDate')(
+            moment()
+              .subtract(1, 'year')
+              .startOf('year')
+          )
+          this.get('onUpdateToDate')(
+            moment()
+              .subtract(1, 'year')
+              .endOf('year')
+          )
           break
       }
     }

--- a/app/statistics/template.hbs
+++ b/app/statistics/template.hbs
@@ -107,7 +107,10 @@
             on-change = (action (mut toDate))
           }}
         {{/fs.label}}
-        {{date-buttons presetDate=(action (mut fromDate))}}
+        {{date-buttons
+            onUpdateFromDate=(action (mut fromDate))
+            onUpdateToDate=(action (mut toDate))
+        }}
       {{/fs.group}}
       {{#fs.group label='State'}}
         {{#fs.label}}

--- a/tests/integration/components/date-buttons/component-test.js
+++ b/tests/integration/components/date-buttons/component-test.js
@@ -12,26 +12,68 @@ describe('Integration | Component | date buttons', function() {
 
   it('changes the date', async function() {
     const format = 'YYYY-MM-DD'
-    this.set('date', null)
+    this.set('fromDate', null)
+    this.set('toDate', null)
 
-    this.render(hbs`{{date-buttons presetDate=(action (mut date))}}`)
+    this.render(
+      hbs`{{date-buttons onUpdateFromDate=(action (mut fromDate)) onUpdateToDate=(action (mut toDate))}}`
+    )
 
     await click('[data-test-preset-date="0"]')
-    expect(this.get('date').format(format)).to.equal(
+    expect(this.get('fromDate').format(format)).to.equal(
       moment()
         .day(1)
         .format(format)
     )
     await click('[data-test-preset-date="1"]')
-    expect(this.get('date').format(format)).to.equal(
+    expect(this.get('fromDate').format(format)).to.equal(
       moment()
         .date(1)
         .format(format)
     )
     await click('[data-test-preset-date="2"]')
-    expect(this.get('date').format(format)).to.equal(
+    expect(this.get('fromDate').format(format)).to.equal(
       moment()
         .dayOfYear(1)
+        .format(format)
+    )
+    await click('[data-test-preset-date="3"]')
+    expect(this.get('fromDate').format(format)).to.equal(
+      moment()
+        .subtract(1, 'week')
+        .day(1)
+        .format(format)
+    )
+    expect(this.get('toDate').format(format)).to.equal(
+      moment()
+        .subtract(1, 'week')
+        .day(7)
+        .format(format)
+    )
+    await click('[data-test-preset-date="4"]')
+    expect(this.get('fromDate').format(format)).to.equal(
+      moment()
+        .subtract(1, 'month')
+        .startOf('month')
+        .format(format)
+    )
+    expect(this.get('toDate').format(format)).to.equal(
+      moment()
+        .subtract(1, 'month')
+        .endOf('month')
+        .format(format)
+    )
+    await click('[data-test-preset-date="5"]')
+    expect(this.get('fromDate').format(format)).to.equal(
+      moment()
+        .subtract(1, 'year')
+        .startOf('year')
+        .format(format)
+    )
+    expect(this.get('toDate').format(format)).to.equal(
+      moment()
+        .subtract(1, 'year')
+        .endOf('year')
         .format(format)
     )
   })


### PR DESCRIPTION
This will allow to filter reports by last week, last month and last
year in Analysis and Statistics.