### PR TITLE
Fix different behavior between Chrome and Firefox

### DIFF
--- a/app/index/reports/controller.js
+++ b/app/index/reports/controller.js
@@ -54,7 +54,7 @@ export default Controller.extend({
         this.store.createRecord('report', { date: this.get('model') })
       }
 
-      return reportsToday.sort(a => (a.get('isNew') ? 1 : -1))
+      return reportsToday.sort(a => (a.get('isNew') ? 1 : 0))
     }
   )
 })

--- a/testem.js
+++ b/testem.js
@@ -6,9 +6,9 @@ module.exports = {
   disable_watching: true,
   parallel: -1,
   launch_in_dev: [],
-  launch_in_ci: ['chromium', 'firefox'],
+  launch_in_ci: ['chrome', 'firefox'],
   browser_args: {
-    chromium: [
+    chrome: [
       process.env.TRAVIS ? '--no-sandbox' : null,
 
       '--headless',


### PR DESCRIPTION
Reports that are not new should preserve their sorting order instead of
resorting. This should prevent a newly created report from being moved
to the top in Chrome.
Also, use Chrome instead of Chromium to run tests in CI.