### PR TITLE
fix: budget label instead of estimate in progress tooltip

### DIFF
--- a/app/components/progress-tooltip/template.hbs
+++ b/app/components/progress-tooltip/template.hbs
@@ -4,7 +4,7 @@
       <div class="time-info-durations">
         <p>Spent (Total): {{humanize-duration spent}}</p>
         <p>Spent (Billable): {{humanize-duration billable}}</p>
-        <p>Estimate: {{if estimated (humanize-duration estimated) 'None'}}</p>
+        <p>Budget: {{if estimated (humanize-duration estimated) 'None'}}</p>
       </div>
       {{#if progress}}
         <div class="time-info-percentage">

--- a/tests/integration/components/progress-tooltip/component-test.js
+++ b/tests/integration/components/progress-tooltip/component-test.js
@@ -50,7 +50,7 @@ module("Integration | Component | progress tooltip", function(hooks) {
 
       assert
         .dom(".progress-tooltip .time-info .time-info-durations p:nth-child(3)")
-        .hasText("Estimate: 50h 0m");
+        .hasText("Budget: 50h 0m");
     });
   });
 
@@ -84,7 +84,7 @@ module("Integration | Component | progress tooltip", function(hooks) {
 
       assert
         .dom(".progress-tooltip .time-info .time-info-durations p:nth-child(3)")
-        .hasText("Estimate: 100h 30m");
+        .hasText("Budget: 100h 30m");
     });
   });
 


### PR DESCRIPTION
"Budget" seems more appropriate than "Estimate" and was also specified in the feature request for the progress tooltip