### PR TITLE
fix(tracking): Fetch most frequent tasks only once

### DIFF
--- a/app/services/tracking.js
+++ b/app/services/tracking.js
@@ -223,7 +223,7 @@ export default Service.extend({
       my_most_frequent: 10, // eslint-disable-line camelcase
       include: "project,project.customer"
     });
-  }),
+  }).drop(),
 
   /**
    * All users


### PR DESCRIPTION
Since it's the same request on each report, it needs to be fetched
only once. This will highly optimize the performance and UX.