### PR TITLE
Revert "fix(auth): Redirect to SSO if authentication fails"

### DIFF
--- a/app/protected/route.js
+++ b/app/protected/route.js
@@ -25,20 +25,14 @@ export default Route.extend(AuthenticatedRouteMixin, {
   media: service("media"),
   store: service(),
   ajax: service(),
-  router: service(),
 
   async model() {
-    let user;
-    try {
-      user = await this.ajax.request("/api/v1/users/me", {
-        method: "GET",
-        data: {
-          include: "supervisors,supervisees"
-        }
-      });
-    } catch (error) {
-      this.router.transitionTo("login");
-    }
+    const user = await this.ajax.request("/api/v1/users/me", {
+      method: "GET",
+      data: {
+        include: "supervisors,supervisees"
+      }
+    });
 
     await this.store.pushPayload("user", user);
 


### PR DESCRIPTION
Reverts adfinis-sygroup/timed-frontend#471

There is no need to redirect to the login page manually as `ember-simple-auth` does that anyway if a request is made with an invalid token.