### PR TITLE
fix: mark package private so it won't get used as dependent

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/adfinis-sygroup/timed-frontend",
   "author": "Adfinis AG <info@adfinis.com>",
   "license": "AGPL-3.0",
+  "private": true,
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
This should fix the dependents on [the dependant overview](https://github.com/adfinis-sygroup/timed-frontend/network/dependents) from dependabot.

Given that there is a `timed` package on npm that does some timing stuff we should mark ours private.

This was introduced years ago in #98 with 7c5ba7163f4d250721391b905e8ecffcf2bfea04.