### PR TITLE
chore: drop CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-# Code owners for the Timed frontend. We include our backend dev team here.
-# Since this is a split project (backend/frontend) it's rather simple
-* @adfinis-sygroup/dev-frontend


### PR DESCRIPTION
I think it's more reasonable to leave notifications up to personal configuration. A large part of the frontend team is not working actively on this project, and the code ownership generates unnecessary notifications.