### PR TITLE
fix(view): make page-permission a tagless component

### DIFF
--- a/app/components/page-permission/component.js
+++ b/app/components/page-permission/component.js
@@ -1,3 +1,5 @@
 import Component from "@ember/component";
 
-export default Component.extend({});
+export default Component.extend({
+  tagName: ""
+});

--- a/app/components/page-permission/template.hbs
+++ b/app/components/page-permission/template.hbs
@@ -4,5 +4,5 @@
     <h4>You do not have the permission to access this page</h4>
   </div>
 {{else}}
- {{yield}}
+  {{yield}}
 {{/if}}


### PR DESCRIPTION
This is needed otherwise it breaks the view on analysis and
statistics.