### PR TITLE
fix(analysis): do not allow to edit reports once they are verified

### DIFF
--- a/app/abilities/report.js
+++ b/app/abilities/report.js
@@ -8,7 +8,7 @@ export default Ability.extend({
     function() {
       const isEditable =
         this.get("user.isSuperuser") ||
-        (!(this.get("model.verifiedBy.id") && this.get("model.billed")) &&
+        (!(this.get("model.verifiedBy.id") || this.get("model.billed")) &&
           (this.get("model.user.id") === this.get("user.id") ||
             (this.get("model.user.supervisors") ?? [])
               .mapBy("id")

--- a/tests/acceptance/analysis-test.js
+++ b/tests/acceptance/analysis-test.js
@@ -20,12 +20,12 @@ module("Acceptance | analysis", function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function() {
-    const user = this.server.create("user");
+    this.user = this.server.create("user");
 
     // eslint-disable-next-line camelcase
-    await authenticateSession({ user_id: user.id });
+    await authenticateSession({ user_id: this.user.id });
 
-    this.server.createList("report", 40, { userId: user.id });
+    this.server.createList("report", 40, { userId: this.user.id });
   });
 
   // TODO enable this
@@ -203,5 +203,22 @@ module("Acceptance | analysis", function(hooks) {
     await click("[data-test-edit-selected]");
 
     assert.ok(currentURL().includes("id=1%2C2"));
+  });
+
+  test("cannot edit verified reports", async function(assert) {
+    const verifier = this.server.create("user");
+
+    this.server.create("report", {
+      userId: this.user.id,
+      verifiedBy: verifier
+    });
+
+    await visit(`/analysis?user=${this.user.id}`);
+
+    await find(".table--analysis tbody tr:last-child").scrollIntoView();
+    await click("tbody > tr:last-child");
+
+    assert.notOk(find("tbody > tr:last-child.selected"));
+    assert.dom("[data-test-edit-selected]").doesNotExist();
   });
 });


### PR DESCRIPTION
This fixes the issue where the reports had to be verified AND billed in order to
make them non-editable. The reports should not be editable once
they are verified OR billed.