### PR TITLE
fix(ability): can't edit reports if verified and reviewer

### DIFF
--- a/app/abilities/report.js
+++ b/app/abilities/report.js
@@ -8,18 +8,19 @@ export default Ability.extend({
     function() {
       const isEditable =
         this.get("user.isSuperuser") ||
-        (!(this.get("model.verifiedBy.id") || this.get("model.billed")) &&
+        (!this.get("model.verifiedBy.id") &&
           (this.get("model.user.id") === this.get("user.id") ||
             (this.get("model.user.supervisors") ?? [])
               .mapBy("id")
               .includes(this.get("user.id"))));
-      const isReviewer = (this.get("model.taskAssignees") ?? [])
-        .concat(
-          this.get("model.projectAssignees") ?? [],
-          this.get("model.customerAssignees") ?? []
-        )
-        .mapBy("user.id")
-        .includes(this.get("user.id"));
+      const isReviewer =
+        (this.get("model.taskAssignees") ?? [])
+          .concat(
+            this.get("model.projectAssignees") ?? [],
+            this.get("model.customerAssignees") ?? []
+          )
+          .mapBy("user.id")
+          .includes(this.get("user.id")) && !this.get("model.verifiedBy.id");
       return isEditable || isReviewer;
     }
   )


### PR DESCRIPTION
You cannot update a report, if the corresponding project is set to billed.
I removed the billed permissions for now, as it cause us some problems.
Backend part for setting "billed"-flag isn't even implemented properly.