### PR TITLE
fix(styling): fix overlapping eye-icon in comment field

### DIFF
--- a/app/analysis/edit/template.hbs
+++ b/app/analysis/edit/template.hbs
@@ -89,10 +89,13 @@
                     <input
                       type="text"
                       placeholder="Enter comment..."
-                      class="form-control"
+                      class="form-control comment-field"
                       onchange={{action fi.update value='target.value'}}
                       value={{fi.value}}
                     >
+                    {{#if model.task.project.customerVisible}}
+                      <CustomerVisibleIcon class="customer-visible-icon" />
+                    {{/if}}
                   </f.input>
 
                   <f.input

--- a/app/components/report-row/template.hbs
+++ b/app/components/report-row/template.hbs
@@ -7,7 +7,7 @@
 <div class="form-list-cell form-group">
   <input
     type="text"
-    class="form-control"
+    class="form-control comment-field"
     placeholder="Comment"
     name="comment"
     value={{changeset.comment}}

--- a/app/components/tracking-bar/styles.scss
+++ b/app/components/tracking-bar/styles.scss
@@ -31,3 +31,9 @@
     width: 100%;
   }
 }
+
+@media #{$xs-viewport} {
+  .form-control {
+    padding-right: 35px;
+  }
+}

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -12,7 +12,7 @@
       <div class="form-group">
         <input
           type="text"
-          class="form-control"
+          class="form-control comment-field"
           placeholder="Comment"
           name="comment"
           value={{changeset.comment}}

--- a/app/index/activities/template.hbs
+++ b/app/index/activities/template.hbs
@@ -44,7 +44,7 @@
                 {{/if}}
               </td>
               <td title={{activity.comment}}>
-                <div>{{activity.comment}}</div>
+                <div class="comment-field">{{activity.comment}}</div>
                 {{#if activity.task.project.customerVisible }}
                   <CustomerVisibleIcon class="activity-customer-visible-icon" />
                 {{/if}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -117,6 +117,10 @@ strong {
   }
 }
 
+.comment-field {
+  padding-right: 35px;
+}
+
 .btn-group--auto .btn {
   flex-grow: 1;
 }
@@ -302,20 +306,24 @@ strong {
   position: relative;
   float: right;
   margin-top: -1.7rem;
-  margin-right: 1rem;
+  margin-right: 0.8rem;
   z-index: 1;
 }
 
 @media (max-width: 680px) {
   .activity-customer-visible-icon {
     margin-top: 0rem;
-    margin-left : 90%;
+    margin-right: 10px;
   }
 
   .customer-visible-icon {
     margin-top: -2.5rem;
   }
 }
+
+  .customer-visible-icon {
+    margin-top: -1.7rem;
+  }
 
 @media #{$sm-viewport} {
   .activity-customer-visible-icon {
@@ -326,8 +334,8 @@ strong {
 
 @media #{$md-viewport} {
   .activity-customer-visible-icon {
-    margin-top: -22px;
-    margin-left: 90%;
+    margin-top: -30px;
+    margin-left: 95%;
   }
 
   .customer-visible-icon {


### PR DESCRIPTION
added customer-visible-icon to analysis-edit

preview of the change:
- analysis-edit report
![added_icon](https://user-images.githubusercontent.com/55092761/140950879-893f9d98-42c3-446d-866b-a0052902ead1.png)
- activities index/edit
![added_padding2](https://user-images.githubusercontent.com/55092761/140950883-46c1e7df-69f5-4b61-b1c5-355e202844b6.png)
- tracking-bar, timesheet index
![added_padding1](https://user-images.githubusercontent.com/55092761/140950884-ab94887e-e71a-4727-bfb1-c91040abc2dd.png)
