### PR TITLE
feat: create view for users with no permission

### DIFF
--- a/app/no-access/route.js
+++ b/app/no-access/route.js
@@ -1,0 +1,3 @@
+import Route from "@ember/routing/route";
+
+export default Route.extend({});

--- a/app/no-access/template.hbs
+++ b/app/no-access/template.hbs
@@ -1,0 +1,6 @@
+<div class="empty">
+  <div>
+    <FaIcon @icon="ban" />
+    <h3>You do not have permission to access Timed.</h3>
+  </div>
+</div>

--- a/app/protected/route.js
+++ b/app/protected/route.js
@@ -39,11 +39,15 @@ export default Route.extend(AuthenticatedRouteMixin, {
     const usermodel = await this.store.peekRecord("user", user.data.id);
 
     // Fetch current employment
-    await this.store.query("employment", {
+    const employment = await this.store.query("employment", {
       user: usermodel.id,
       date: moment().format("YYYY-MM-DD"),
       include: "location"
     });
+
+    if (!employment.length) {
+      this.transitionTo("no-access");
+    }
 
     this.set("session.data.user", usermodel);
 

--- a/app/router.js
+++ b/app/router.js
@@ -12,6 +12,7 @@ const resetNamespace = true;
 // eslint-disable-next-line array-callback-return
 ApplicationRouter.map(function() {
   this.route("login");
+  this.route("no-access");
 
   this.route("protected", { path: "/" }, function() {
     this.route("index", { resetNamespace, path: "/" }, function() {

--- a/tests/unit/no-access/route-test.js
+++ b/tests/unit/no-access/route-test.js
@@ -1,0 +1,11 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Route | no-access", function(hooks) {
+  setupTest(hooks);
+
+  test("it exists", function(assert) {
+    const route = this.owner.lookup("route:no-access");
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
Only users with an internal or external employment are allowed to
access timed. Users such as customers will be forwarded to the new
`no-access` page, where a message will be displayed that they do
not have the permission to access Timed.